### PR TITLE
Debounce Pending Flag

### DIFF
--- a/docs/.vuepress/examples/validation-flags.vue
+++ b/docs/.vuepress/examples/validation-flags.vue
@@ -11,6 +11,7 @@
       pristine,
       dirty,
       pending,
+      pendingValidation,
       required,
       validated,
       passed,
@@ -27,6 +28,7 @@
       <li :class="`is-${pristine}`">pristine: {{ pristine }}</li>
       <li :class="`is-${dirty}`">dirty: {{ dirty }}</li>
       <li :class="`is-${pending}`">pending: {{ pending }}</li>
+      <li :class="`is-${pendingValidation}`">pendingValidation: {{ pendingValidation }}</li>
       <li :class="`is-${required}`">required: {{ required }}</li>
       <li :class="`is-${validated}`">validated: {{ validated }}</li>
       <li :class="`is-${passed}`">passed: {{ passed }}</li>

--- a/src/components/Provider.ts
+++ b/src/components/Provider.ts
@@ -283,6 +283,7 @@ export const ValidationProvider = (Vue as withProviderPrivates).extend({
 
       this.setFlags({
         pending: false,
+        pendingDebounce: false,
         valid: result.valid,
         invalid: !result.valid
       });

--- a/src/components/Provider.ts
+++ b/src/components/Provider.ts
@@ -283,7 +283,6 @@ export const ValidationProvider = (Vue as withProviderPrivates).extend({
 
       this.setFlags({
         pending: false,
-        pendingDebounce: false,
         valid: result.valid,
         invalid: !result.valid
       });
@@ -303,6 +302,7 @@ export const ValidationProvider = (Vue as withProviderPrivates).extend({
         invalid: !!errors.length,
         failed: !!errors.length,
         validated: true,
+        pendingDebounce: false,
         changed: this.value !== this.initialValue
       });
     },

--- a/src/components/common.ts
+++ b/src/components/common.ts
@@ -145,7 +145,7 @@ export function createCommonHandlers(vm: ProviderInstance) {
   // Handle debounce changes.
   if (!onValidate || vm.$veeDebounce !== vm.debounce) {
 
-    onValidate = () => {
+    onValidate = (...args: any[]) => {
       vm.setFlags({ pendingDebounce: true });
       return debounce(() => {
         vm.$nextTick(() => {
@@ -155,7 +155,7 @@ export function createCommonHandlers(vm: ProviderInstance) {
 
           vm._pendingReset = false;
         });
-      }, mode.debounce || vm.debounce)
+      }, mode.debounce || vm.debounce)(args);
     };
 
     // Cache the handler so we don't create it each time.

--- a/src/components/common.ts
+++ b/src/components/common.ts
@@ -144,15 +144,19 @@ export function createCommonHandlers(vm: ProviderInstance) {
 
   // Handle debounce changes.
   if (!onValidate || vm.$veeDebounce !== vm.debounce) {
-    onValidate = debounce(() => {
-      vm.$nextTick(() => {
-        if (!vm._pendingReset) {
-          triggerThreadSafeValidation(vm);
-        }
 
-        vm._pendingReset = false;
-      });
-    }, mode.debounce || vm.debounce);
+    onValidate = () => {
+      vm.setFlags({ pendingDebounce: true });
+      return debounce(() => {
+        vm.$nextTick(() => {
+          if (!vm._pendingReset) {
+            triggerThreadSafeValidation(vm);
+          }
+
+          vm._pendingReset = false;
+        });
+      }, mode.debounce || vm.debounce)
+    };
 
     // Cache the handler so we don't create it each time.
     vm.$veeHandler = onValidate;

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,7 @@ export interface ValidationFlags {
   failed: boolean;
   validated: boolean;
   pending: boolean;
+  pendingDebounce: boolean;
   required: boolean;
   changed: boolean;
   [x: string]: boolean | undefined;

--- a/src/utils/factories.ts
+++ b/src/utils/factories.ts
@@ -10,6 +10,7 @@ export function createFlags(): ValidationFlags {
     invalid: false,
     validated: false,
     pending: false,
+    pendingDebounce: false,
     required: false,
     changed: false,
     passed: false,

--- a/tests/providers/provider.js
+++ b/tests/providers/provider.js
@@ -748,6 +748,33 @@ test('validation can be debounced', async () => {
   expect(error.text()).toBe(DEFAULT_REQUIRED_MESSAGE);
 });
 
+test('pendingDebounce gets set properly', async () => {
+  const wrapper = mount(
+    {
+      data: () => ({
+        value: ''
+      }),
+      template: `
+        <ValidationProvider ref="provider" rules="required" :debounce="50" v-slot="{ pendingDebounce }">
+          <input v-model="value" type="text">
+          <p>{{pendingDebounce}}</p>
+        </ValidationProvider>
+      `
+    },
+    { localVue: Vue, sync: false }
+  );
+
+  const input = wrapper.find('input');
+  const pendingDebounce = wrapper.find('p');
+
+  input.setValue('');
+  await sleep(40);
+  expect(pendingDebounce.text()).toBe('true');
+  await sleep(10);
+  await flushPromises();
+  expect(pendingDebounce.text()).toBe('false');
+});
+
 test('reset ignores pending validation result', async () => {
   const wrapper = mount(
     {

--- a/tests/providers/provider.js
+++ b/tests/providers/provider.js
@@ -755,7 +755,7 @@ test('pendingDebounce gets set properly', async () => {
         value: ''
       }),
       template: `
-        <ValidationProvider ref="provider" rules="required" :debounce="50" v-slot="{ pendingDebounce }">
+        <ValidationProvider rules="required" :debounce="50" v-slot="{ pendingDebounce }">
           <input v-model="value" type="text">
           <p>{{pendingDebounce}}</p>
         </ValidationProvider>


### PR DESCRIPTION
🔎 __Overview__

This PR adds a new pending flag for debounce.

When typing into a provider with a debounce, the 'pending' flag doesn't get set until the validation occurs. This new flag will get set at the start of the debounce timeout and won't get resolved until after validation.

🤓 __Code snippets/examples (if applicable)__

```js
<ValidationObserver v-slot="{ pendingDebounce, invalid }">
    <ValidationProvider rules="required" :debounce="500">
        <input v-model="value" type="text">
    </ValidationProvider>
    <button type="submit" :disabled="pendingDebounce || invalid">Submit</button>
</ValidationObserver>
```

✔ __Issues affected__

list of issues formatted like this:

> closes #2805
